### PR TITLE
Add comments when dumping

### DIFF
--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -55,9 +55,12 @@ _REMOVE_TRAILING_COMMA = r"""
 
 
 _ADD_TRAILING_COMMA = r"""
-   # Don't match opening braces to avoid {,}
-   ([^,\[{\s])
-   (?=\s*([\]}]))
+    ( # String Literal
+        \"(?:\\.|[^\\\"])*?\"
+    )
+    | # Don't match opening braces to avoid {,}
+    ((?<=\")|[^,\[{\s])
+    (?=\s*([\]}]))
 """
 
 
@@ -81,7 +84,7 @@ def _remove_trailing_comma(text: str) -> str:
 def _add_trailing_comma(text: str) -> str:
     return re.sub(
         _ADD_TRAILING_COMMA,
-        lambda x: x.group(1) + ",",
+        lambda x: x.group(1) or x.group(2) + ",",
         text,
         flags=re.DOTALL | re.VERBOSE,
     )

--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -13,13 +13,24 @@ r"""JSON with Comments for Python
 
 from __future__ import annotations
 
+from io import StringIO
+from tokenize import NL, STRING, COMMENT, TokenInfo, generate_tokens, untokenize
 from collections.abc import Callable
-from typing import Any, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 __version__ = "1.1.1"
 import json
 import re
-from json import JSONDecoder, dump, dumps  # for compatibility
+from json import JSONDecoder, JSONEncoder  # for compatibility
+
+if TYPE_CHECKING:
+    Comments = (
+        str
+        | dict[str, "Comments"]
+        | dict[int, "Comments"]
+        | tuple[str, dict[str, "Comments"] | dict[int, "Comments"]]
+    )
+
 
 _REMOVE_C_COMMENT = r"""
     ( # String Literal
@@ -43,6 +54,13 @@ _REMOVE_TRAILING_COMMA = r"""
 """
 
 
+_ADD_TRAILING_COMMA = r"""
+   # Don't match opening braces to avoid {,}
+   ([^,\[{\s])
+   (?=\s*([\]}]))
+"""
+
+
 def _remove_c_comment(text: str) -> str:
     if text[-1] != "\n":
         text = text + "\n"
@@ -58,6 +76,38 @@ def _remove_trailing_comma(text: str) -> str:
         text,
         flags=re.DOTALL | re.VERBOSE,
     )
+
+
+def _add_trailing_comma(text: str) -> str:
+    return re.sub(
+        _ADD_TRAILING_COMMA,
+        lambda x: x.group(1) + ",",
+        text,
+        flags=re.DOTALL | re.VERBOSE,
+    )
+
+
+def _make_comment(text: str, indent=0) -> str:
+    return "\n".join(
+        " " * indent + "// " + line if line else "" for line in text.splitlines()
+    )
+
+
+def _get_comments(comments, key):
+    if isinstance(comments, dict):
+        if isinstance(key, str):
+            key = json.loads(key)
+        comments = comments.get(key)
+    else:
+        comments = None
+
+    if isinstance(comments, tuple):
+        comm, comments = comments
+    elif isinstance(comments, str):
+        comm = comments
+    else:
+        comm = None
+    return comm, comments
 
 
 def load(
@@ -113,4 +163,159 @@ def loads(
         parse_constant=parse_constant,
         object_pairs_hook=object_pairs_hook,
         **kw,
+    )
+
+
+def add_comments(data: str, comments: Comments) -> str:
+    header, comments = _get_comments({0: comments}, 0)
+    if header:
+        header = _make_comment(header) + "\n"
+    else:
+        header = ""
+    result = []
+    stack = []
+    line_shift = 0
+    array_index: int | None = None
+    for token in generate_tokens(StringIO(data).readline):
+        if (
+            token.type == STRING or (array_index is not None and token.string != "]")
+        ) and result[-1].type == NL:
+            stack.append((comments, array_index))
+            comm, comments = _get_comments(
+                comments, array_index if array_index is not None else token.string
+            )
+            if comm:
+                comm = _make_comment(comm, token.start[1])
+                comm_coord = (token.start[0] + line_shift, 0)
+                result.append(
+                    TokenInfo(
+                        COMMENT,
+                        comm,
+                        comm_coord,
+                        comm_coord,
+                        "",
+                    )
+                )
+                result.append(
+                    TokenInfo(
+                        NL,
+                        "\n",
+                        comm_coord,
+                        comm_coord,
+                        "",
+                    )
+                )
+                line_shift += 1
+
+        if token.string == ",":
+            comments, array_index = stack.pop()
+            if array_index is not None:
+                array_index += 1
+        elif token.string == "[":
+            stack.append((comments, array_index))
+            array_index = 0
+        elif token.string == "{":
+            stack.append((comments, array_index))
+            array_index = None
+        elif token.string in {"]", "}"}:
+            comments, array_index = stack.pop()
+            if result[-1].type == NL and result[-2].string != ",":
+                comments, array_index = stack.pop()
+
+        token = TokenInfo(
+            token.type,
+            token.string,
+            (token.start[0] + line_shift, token.start[1]),
+            (token.end[0] + line_shift, token.end[1]),
+            token.line,
+        )
+        result.append(token)
+
+    assert not stack, "Error when adding comments to JSON"
+    return header + untokenize(result)
+
+
+def dumps(
+    obj: Any,
+    *,
+    skipkeys=False,
+    ensure_ascii=True,
+    check_circular=True,
+    allow_nan=True,
+    cls: type[JSONEncoder] | None = None,
+    indent: int | None = None,
+    separators: tuple[str, str] | None = None,
+    default: Callable[[Any], Any] | None = None,
+    sort_keys=False,
+    trailing_comma=False,
+    comments: Comments | None = None,
+    **kw,
+) -> str:
+    """Serialize ``obj`` to a JSON formatted ``str``.
+
+    Reference: ``json.dumps``
+    """
+
+    data = json.dumps(
+        obj,
+        skipkeys=skipkeys,
+        ensure_ascii=ensure_ascii,
+        check_circular=check_circular,
+        allow_nan=allow_nan,
+        cls=cls,
+        indent=indent,
+        separators=separators,
+        default=default,
+        sort_keys=sort_keys,
+        **kw,
+    )
+
+    if trailing_comma:
+        data = _add_trailing_comma(data)
+
+    if comments is None or indent is None:
+        return data
+
+    return add_comments(data, comments)
+
+
+def dump(
+    obj: Any,
+    fp: TextIO,
+    *,
+    skipkeys=False,
+    ensure_ascii=True,
+    check_circular=True,
+    allow_nan=True,
+    cls: type[JSONEncoder] | None = None,
+    indent: int | None = None,
+    separators: tuple[str, str] | None = None,
+    default: Callable[[Any], Any] | None = None,
+    sort_keys=False,
+    trailing_comma=False,
+    comments: Comments | None = None,
+    **kw,
+):
+    """Serialize ``obj`` as a JSON formatted stream to ``fp`` (a
+    ``.write()``-supporting file-like object).
+
+    Reference: ``json.dump``
+    """
+
+    fp.write(
+        dumps(
+            obj,
+            skipkeys=skipkeys,
+            ensure_ascii=ensure_ascii,
+            check_circular=check_circular,
+            allow_nan=allow_nan,
+            cls=cls,
+            indent=indent,
+            separators=separators,
+            default=default,
+            sort_keys=sort_keys,
+            trailing_comma=trailing_comma,
+            comments=comments,
+            **kw,
+        )
     )

--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -96,7 +96,9 @@ def _make_comment(text: str, indent=0) -> str:
     )
 
 
-def _get_comments(comments, key):
+def _get_comments(
+    comments: Comments | None, key: str | int
+) -> tuple[str | None, Comments | None]:
     if isinstance(comments, dict):
         if isinstance(key, str):
             key = json.loads(key)

--- a/jsonc/__init__.py
+++ b/jsonc/__init__.py
@@ -14,6 +14,7 @@ r"""JSON with Comments for Python
 from __future__ import annotations
 
 from io import StringIO
+from copy import deepcopy
 from warnings import warn
 from tokenize import NL, STRING, COMMENT, TokenInfo, generate_tokens, untokenize
 from collections.abc import Callable
@@ -179,7 +180,7 @@ def loads(
 
 
 def add_comments(data: str, comments: Comments) -> str:
-    header, comments = _get_comments({0: comments}, 0)
+    header, comments = _get_comments({0: deepcopy(comments)}, 0)
     if header:
         header = _make_comment(header) + "\n"
     else:

--- a/tests/test_jsonc.py
+++ b/tests/test_jsonc.py
@@ -36,6 +36,7 @@ def test_dumps():
         dumps({"a": "b", "c": {}}, trailing_comma=True, comments="test")
         == '{"a": "b", "c": {},}'
     )
+    assert dumps("{hello}", trailing_comma=True) == '"{hello}"'
     assert dumps({}, indent=2, comments="test") == "// test\n{}"
     obj = {"a": {"b": "c"}, "d": [1, [2, 3], {"x": [6.7, [{}]]}]}
     comments = (

--- a/tests/test_jsonc.py
+++ b/tests/test_jsonc.py
@@ -6,6 +6,8 @@ try:
 except ImportError:
     import tomli as tomllib  # type: ignore
 
+import pytest
+
 
 def test_version():
     with open("pyproject.toml", "rb") as f:
@@ -32,12 +34,15 @@ def test_load():
 
 def test_dumps():
     assert dumps({}) == "{}"
-    assert (
-        dumps({"a": "b", "c": {}}, trailing_comma=True, comments="test")
-        == '{"a": "b", "c": {},}'
-    )
+    with pytest.warns(UserWarning):
+        assert (
+            dumps({"a": "b", "c": {}}, trailing_comma=True, comments="test")
+            == '{"a": "b", "c": {},}'
+        )
     assert dumps("{hello}", trailing_comma=True) == '"{hello}"'
     assert dumps({}, indent=2, comments="test") == "// test\n{}"
+    with pytest.warns(UserWarning):
+        assert dumps({}, indent=2, comments={"a": "b"}) == "{}"
     obj = {"a": {"b": "c"}, "d": [1, [2, 3], {"x": [6.7, [{}]]}]}
     comments = (
         "test2",

--- a/tests/test_jsonc.py
+++ b/tests/test_jsonc.py
@@ -1,5 +1,6 @@
 from jsonc import __version__, load, loads, dump, dumps
 from io import StringIO
+from copy import deepcopy
 
 try:
     import tomllib  # type: ignore
@@ -58,6 +59,7 @@ def test_dumps():
             },
         },
     )
+    orig_comments = deepcopy(comments)
 
     expected = """
 // test2
@@ -91,6 +93,7 @@ def test_dumps():
 }
     """.strip()
     assert dumps(obj, indent=2, comments=comments) == expected
+    assert comments == orig_comments
     assert (
         dumps(obj, indent=2, trailing_comma=True, comments=comments).count(",")
         - expected.count(",")

--- a/tests/test_jsonc.py
+++ b/tests/test_jsonc.py
@@ -1,4 +1,5 @@
-from jsonc import __version__, load, loads
+from jsonc import __version__, load, loads, dump, dumps
+from io import StringIO
 
 try:
     import tomllib  # type: ignore
@@ -27,3 +28,71 @@ def test_loads():
 def test_load():
     with open("tests/testfile.jsonc", "r", encoding="utf-8") as f:
         load(f)
+
+
+def test_dumps():
+    assert dumps({}) == "{}"
+    assert (
+        dumps({"a": "b", "c": {}}, trailing_comma=True, comments="test")
+        == '{"a": "b", "c": {},}'
+    )
+    assert dumps({}, indent=2, comments="test") == "// test\n{}"
+    obj = {"a": {"b": "c"}, "d": [1, [2, 3], {"x": [6.7, [{}]]}]}
+    comments = (
+        "test2",
+        {
+            "a": ("nested dict", {"b": "nested key"}),
+            "d": {
+                0: "first array element",
+                1: ("second element", {0: "first element of second element"}),
+                2: (
+                    "third element",
+                    {"x": ("something", {1: "empty object/array test"})},
+                ),
+            },
+        },
+    )
+
+    expected = """
+// test2
+{
+  // nested dict
+  "a": {
+    // nested key
+    "b": "c"
+  },
+  "d": [
+    // first array element
+    1,
+    // second element
+    [
+      // first element of second element
+      2,
+      3
+    ],
+    // third element
+    {
+      // something
+      "x": [
+        6.7,
+        // empty object/array test
+        [
+          {}
+        ]
+      ]
+    }
+  ]
+}
+    """.strip()
+    assert dumps(obj, indent=2, comments=comments) == expected
+    assert (
+        dumps(obj, indent=2, trailing_comma=True, comments=comments).count(",")
+        - expected.count(",")
+        == 7
+    )
+
+
+def test_dump():
+    o = StringIO()
+    dump([], o, indent=2, comments="test")
+    assert o.getvalue() == "// test\n[]"


### PR DESCRIPTION
I thought it'd be useful to have a possibility to add comments when dumping by passing `comments=...` to `dump(s)`. Also I've added `trailing_comma` arg that adds trailing commas everywhere.