### PR TITLE
Mark tomli as a dev dependency, instead of a main dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,11 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.7, <3.13"
-tomli = { version = "^2.0.1", python = "<3.11" }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"
 tox = ">=3.27,<5.0"
+tomli = { version = "^2.0.1", python = "<3.11" }
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
tomli is only needed for the tests, not for the actual package. Mark it as a dev dependency, so that the generated wheel does not needlessly depend on tomli.